### PR TITLE
chore(package): add standard-version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 > docker inspect → docker run
 
+[![Standard Version](https://img.shields.io/badge/release-standard%20version-brightgreen.svg)](https://github.com/conventional-changelog/standard-version)
+
 A simple module to reverse engineer a `docker run` command from an existing container (via `docker inspect`). Just pass in the container names or ids that you want to reverse engineer and `rekcod` will output a `docker run` command that duplicates the container.
 
 This is not super robust, but it should hopefully cover most arguments needed.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "pretest": "standard",
-    "test": "nyc ava"
+    "test": "nyc ava",
+    "release": "standard-version"
   },
   "repository": {
     "type": "git",
@@ -24,5 +25,8 @@
   "bugs": {
     "url": "https://github.com/nexdrew/rekcod/issues"
   },
-  "homepage": "https://github.com/nexdrew/rekcod#readme"
+  "homepage": "https://github.com/nexdrew/rekcod#readme",
+  "devDependencies": {
+    "standard-version": "^2.1.2"
+  }
 }


### PR DESCRIPTION
A better alternative to `npm version`. Use `npm run release` instead - automatic semver bump, changelog generation, and git tagging!