### PR TITLE
Interpret ExtraHosts parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,6 +96,8 @@ function toRunCommand (inspectObj, name) {
     })
   }
 
+  if (hostcfg.ExtraHosts) rc = appendJoinedArray(rc, '--add-host', hostcfg.ExtraHosts, ' ')
+
   let cfg = inspectObj.Config || {}
   if (cfg.Hostname) rc = append(rc, '-h', cfg.Hostname)
   if (cfg.ExposedPorts) {


### PR DESCRIPTION
Hi, I just added a new feature, which interprets `ExtraHosts` parameter in the docker container, to rekcod.