### PR TITLE
feat: add support for ExtraHosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ rekcod(['another-name', '6653931e39f2', 'happy_torvalds'], (err, run) => {
 | `HostConfig.PublishAllPorts` | `-P`             |
 | `HostConfig.NetworkMode`     | `--net`          |
 | `HostConfig.RestartPolicy`   | `--restart`      |
+| `HostConfig.ExtraHosts`      | `--add-host`     |
 | `Config.Hostname`            | `-h`             |
 | `Config.ExposedPorts`        | `--expose`       |
 | `Config.Env`                 | `-e`             |

--- a/index.js
+++ b/index.js
@@ -96,6 +96,8 @@ function toRunCommand (inspectObj, name) {
     })
   }
 
+  if (hostcfg.ExtraHosts) rc = appendJoinedArray(rc, '--add-host', hostcfg.ExtraHosts, ' ')
+
   let cfg = inspectObj.Config || {}
   if (cfg.Hostname) rc = append(rc, '-h', cfg.Hostname)
   if (cfg.ExposedPorts) {

--- a/index.js
+++ b/index.js
@@ -95,8 +95,7 @@ function toRunCommand (inspectObj, name) {
       return policy.Name === 'on-failure' ? policy.Name + ':' + policy.MaximumRetryCount : policy.Name
     })
   }
-
-  if (hostcfg.ExtraHosts) rc = appendJoinedArray(rc, '--add-host', hostcfg.ExtraHosts, ' ')
+  rc = appendArray(rc, '--add-host', hostcfg.ExtraHosts)
 
   let cfg = inspectObj.Config || {}
   if (cfg.Hostname) rc = append(rc, '-h', cfg.Hostname)


### PR DESCRIPTION
Supersedes #9 by fixing the logic to properly handle multiple values for `ExtraHosts`. Also adds the new supported field to the README doc.