### PR TITLE
feat: accept container, file, or json

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -58,11 +58,7 @@ function processArgs (args) {
   let filesRunning = 0
   objects.filter(Boolean).forEach((o) => {
     if (o.type === 'json') {
-      try {
-        o.run = [].concat(rekcod.translate(o.val))
-      } catch (err) {
-        handleError(err)
-      }
+      o.run = [].concat(rekcod.translate(o.val))
     } else if (o.type === 'file') {
       filesRunning++
       rekcod.readFile(o.val, (err, runObjects) => {

--- a/cli.js
+++ b/cli.js
@@ -1,19 +1,101 @@
 #!/usr/bin/env node
 'use strict'
 
-const rekcod = require('./index')
+let args = process.argv.slice(2)
 
-rekcod(process.argv.slice(2), (err, runObjects) => {
-  if (err) {
-    if (err.stdout) console.log(err.stdout)
-    if (err.stderr) console.error(err.stderr)
-    else console.error(err)
-    return process.exit((!isNaN(err.code) && err.code) || 1)
-  }
-
-  runObjects.forEach((r) => {
-    console.log()
-    console.log(r.command)
+if (!args.length) {
+  // grab args from stdin
+  let read = ''
+  process.stdin.resume()
+  process.stdin.setEncoding('utf8')
+  process.stdin.on('data', function (chunk) {
+    read += chunk
   })
-  console.log()
-})
+  process.stdin.on('end', function () {
+    try {
+      args = [ JSON.parse(read) ] // either pipe json blob in from docker inspect
+    } catch (_) {
+      args = read.match(/\S+/g) || process.exit(0) // or pipe container ids from docker ps
+    }
+    processArgs(args)
+  })
+} else {
+  processArgs(args)
+}
+
+function processArgs (args) {
+  const rekcod = require('./index')
+  const fs = require('fs')
+  // determine if each arg represents a container, a file, or json
+  // collect containers so they can be processed together
+  const containers = []
+  const objects = args.map((arg, index) => {
+    if (typeof arg === 'object') return { index, type: 'json', val: arg }
+    try {
+      return { index, type: 'json', val: JSON.parse(arg) }
+    } catch (_) {}
+    try {
+      return { index, type: 'file', val: fs.statSync(arg) && arg }
+    } catch (_) {}
+    containers.push({ index, type: 'container', val: arg })
+    return null
+  })
+
+  // asynchronously process each object and all containers
+  let containersRunning = false
+  if (containers.length) {
+    containersRunning = true
+    rekcod(containers.map((c) => c.val), (err, runObjects) => {
+      handleError(err)
+      for (let i = 0, len = runObjects.length, c; i < len; i++) {
+        c = containers[i]
+        c.run = [ runObjects[i] ]
+        objects[c.index] = c
+      }
+      containersRunning = false
+    })
+  }
+  let filesRunning = 0
+  objects.filter(Boolean).forEach((o) => {
+    if (o.type === 'json') {
+      try {
+        o.run = [].concat(rekcod.translate(o.val))
+      } catch (err) {
+        handleError(err)
+      }
+    } else if (o.type === 'file') {
+      filesRunning++
+      rekcod.readFile(o.val, (err, runObjects) => {
+        handleError(err)
+        o.run = runObjects
+        filesRunning--
+      })
+    }
+  })
+
+  function checkCompletion () {
+    if (!containersRunning && filesRunning === 0) {
+      objects.forEach((o) => {
+        if (!o || !Array.isArray(o.run) || o.run.length === 0) {
+          console.log()
+          return console.log('Nothing to translate')
+        }
+        o.run.forEach((r) => {
+          console.log()
+          console.log(r.command)
+        })
+      })
+      return console.log()
+    }
+    setTimeout(checkCompletion, 20) // check up to 50 times a second
+  }
+  checkCompletion()
+}
+
+function handleError (err) {
+  if (!err) return
+  if (err.stdout) console.log(err.stdout)
+  if (err.stderr) console.error(err.stderr)
+  else console.error(err)
+  process.exit((!isNaN(err.code) && err.code) || 1)
+}

--- a/test/docker
+++ b/test/docker
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-var containers = process.argv.splice(3)
+var containers = process.argv.slice(3)
 if (~containers.indexOf('error')) {
   console.log('Preparing to error out')
   console.error('An error has occurred')

--- a/test/test-cli.js
+++ b/test/test-cli.js
@@ -66,15 +66,8 @@ test('cli handles docker inspect invalid json', (t) => {
 })
 
 test('cli handles docker inspect empty array', (t) => {
-  let err
-  try {
-    cli('empty')
-  } catch (e) {
-    err = e
-  }
-  t.ok(err)
-  t.ok(/Unexpected output/.test(err.stderr))
-  t.equal(err.status, 1)
+  const output = cli('empty')
+  t.equal(output, '\nNothing to translate\n\n')
   t.end()
 })
 

--- a/test/test-cli.js
+++ b/test/test-cli.js
@@ -1,10 +1,12 @@
 'use strict'
 
-const execFileSync = require('child_process').execFileSync
+const childProcess = require('child_process')
+const execFileSync = childProcess.execFileSync
 const path = require('path')
 const test = require('tape')
 
 const cliPath = path.resolve(__dirname, '..', 'cli.js')
+const oneTwoFixture = path.resolve(__dirname, 'fixtures', 'inspect-one-two.json')
 
 function mockedDockerEnv (envPath) {
   const env = JSON.parse(JSON.stringify(process.env))
@@ -19,43 +21,90 @@ function cli (args, envPath) {
   })
 }
 
+const expectedOneTwo = '\n' +
+  'docker run ' +
+  '--name project_service_1 ' +
+  '-v /var/lib/replicated:/var/lib/replicated -v /proc:/host/proc:ro ' +
+  '-p 4700:4700/tcp -p 4702:4702/tcp ' +
+  '--link project_postgres_1:postgres --link project_rrservice_1:project_rrservice_1 ' +
+  '-P ' +
+  '--net host ' +
+  '--restart on-failure:5 ' +
+  '--add-host xyz:1.2.3.4 --add-host abc:5.6.7.8 ' +
+  '-h 9c397236341e ' +
+  '--expose 4700/tcp --expose 4702/tcp ' +
+  '-e DB_USER=postgres -e "no_proxy=*.local, 169.254/16" ' +
+  '-d ' +
+  '--entrypoint "tini -- /docker-entrypoint.sh" ' +
+  'project_service /etc/npme/start.sh -g' +
+  '\n\n' +
+  'docker run ' +
+  '--name hello ' +
+  '--volumes-from admiring_brown --volumes-from silly_jang ' +
+  '--restart no ' +
+  '-h 46d567b2ef86 ' +
+  '-e PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin ' +
+  '-a stdout -a stderr ' +
+  '-t -i ' +
+  'hello-world /hello' +
+  '\n\n'
+
 test('cli works for docker inspect happy path', (t) => {
   const dockerRunCommands = cli('one two')
-  const expected = '\n' +
-    'docker run ' +
-    '--name project_service_1 ' +
-    '-v /var/lib/replicated:/var/lib/replicated -v /proc:/host/proc:ro ' +
-    '-p 4700:4700/tcp -p 4702:4702/tcp ' +
-    '--link project_postgres_1:postgres --link project_rrservice_1:project_rrservice_1 ' +
-    '-P ' +
-    '--net host ' +
-    '--restart on-failure:5 ' +
-    '--add-host xyz:1.2.3.4 --add-host abc:5.6.7.8 ' +
-    '-h 9c397236341e ' +
-    '--expose 4700/tcp --expose 4702/tcp ' +
-    '-e DB_USER=postgres -e "no_proxy=*.local, 169.254/16" ' +
-    '-d ' +
-    '--entrypoint "tini -- /docker-entrypoint.sh" ' +
-    'project_service /etc/npme/start.sh -g' +
-    '\n\n' +
-    'docker run ' +
-    '--name hello ' +
-    '--volumes-from admiring_brown --volumes-from silly_jang ' +
-    '--restart no ' +
-    '-h 46d567b2ef86 ' +
-    '-e PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin ' +
-    '-a stdout -a stderr ' +
-    '-t -i ' +
-    'hello-world /hello' +
-    '\n\n'
-  t.equal(dockerRunCommands, expected)
+  t.equal(dockerRunCommands, expectedOneTwo)
   t.end()
+})
+
+test('cli accepts file name arg', (t) => {
+  const dockerRunCommands = cli(oneTwoFixture)
+  t.equal(dockerRunCommands, expectedOneTwo)
+  t.end()
+})
+
+test('pipe json to cli', (t) => {
+  childProcess.exec(`cat ${oneTwoFixture} | ${cliPath}`, (err, stdout, stderr) => {
+    t.notOk(err)
+    t.equal(stdout, expectedOneTwo)
+    t.end()
+  })
+})
+
+test('pipe file name to cli', (t) => {
+  childProcess.exec(`ls ${oneTwoFixture} | ${cliPath}`, (err, stdout, stderr) => {
+    t.notOk(err)
+    t.equal(stdout, expectedOneTwo)
+    t.end()
+  })
+})
+
+test('pipe container ids to cli', (t) => {
+  childProcess.exec(`echo 'one two' | ${cliPath}`, {
+    env: mockedDockerEnv(),
+    encoding: 'utf8'
+  }, (err, stdout, stderr) => {
+    t.notOk(err)
+    t.equal(stdout, expectedOneTwo)
+    t.end()
+  })
 })
 
 test('cli handles docker inspect invalid json', (t) => {
   let err
   try {
     cli('invalid')
+  } catch (e) {
+    err = e
+  }
+  t.ok(err)
+  t.ok(/Unexpected token d/.test(err.stderr))
+  t.equal(err.status, 1)
+  t.end()
+})
+
+test('cli handles invalid json file', (t) => {
+  let err
+  try {
+    cli(path.resolve(__dirname, 'fixtures', 'inspect-invalid.json'))
   } catch (e) {
     err = e
   }


### PR DESCRIPTION
Fixes #7. Fixes #13.

Major changes:

- rekcod now reads from stdin if no arguments given
- rekcod now accepts json content, file names, or container ids/names (via arguments _or_ stdin)
- more exported functions to make module more useful

Note the **BREAKING CHANGES**:

- no longer errors without arguments (reads from stdin instead)
- no longer errors on empty arrays
- prefers file over container if identically named

TODO:

- [x] Refactor for more betterness
- [x] Update tests to get coverage back to 100%
- [x] Update README