### PR TITLE
chore: manually upgrade dev dependencies to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,10 +32,10 @@
   },
   "homepage": "https://github.com/nexdrew/rekcod#readme",
   "devDependencies": {
-    "coveralls": "^3.0.0",
-    "nyc": "^11.0.2",
-    "standard": "^12.0.0",
-    "standard-version": "^4.0.0",
-    "tape": "^4.6.3"
+    "coveralls": "^3.0.2",
+    "nyc": "^13.1.0",
+    "standard": "^12.0.1",
+    "standard-version": "^4.4.0",
+    "tape": "^4.9.1"
   }
 }


### PR DESCRIPTION
All dependencies except nyc were still in range of latest, but nyc required a major bump. Not sure what's going on with Greenkeeper these days.