### PR TITLE
chore: test on Node 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,6 @@ language: node_js
 node_js:
   - '6'
   - '8'
+  - '10'
   - 'node'
 after_success: npm run coverage


### PR DESCRIPTION
Now that Node 10 is LTS, let's explicitly include it in CI testing.