### PR TITLE
feat: add support for `--runtime` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ array.forEach((r) => {
 | docker inspect               | docker run       |
 | ---------------------------- | ---------------- |
 | `Name`                       | `--name`         |
+| `HostConfig.Runtime`         | `--runtime`      |
 | `HostConfig.Binds`           | `-v`             |
 | `HostConfig.VolumesFrom`     | `--volumes-from` |
 | `HostConfig.PortBindings`    | `-p`             |

--- a/index.js
+++ b/index.js
@@ -86,6 +86,7 @@ function toRunCommand (inspectObj, name) {
   let rc = append('docker run', '--name', name)
 
   let hostcfg = inspectObj.HostConfig || {}
+  if (hostcfg.Runtime) rc = append(rc, '--runtime', hostcfg.Runtime)
   rc = appendArray(rc, '-v', hostcfg.Binds)
   rc = appendArray(rc, '--volumes-from', hostcfg.VolumesFrom)
   if (hostcfg.PortBindings) {

--- a/test/fixtures/inspect-one-two.json
+++ b/test/fixtures/inspect-one-two.json
@@ -287,6 +287,7 @@
       "UTSMode": "",
       "UsernsMode": "",
       "ShmSize": 67108864,
+      "Runtime": "nvidia",
       "ConsoleSize": [
         0,
         0

--- a/test/test-cli.js
+++ b/test/test-cli.js
@@ -24,6 +24,7 @@ function cli (args, envPath) {
 const expectedOneTwo = '\n' +
   'docker run ' +
   '--name project_service_1 ' +
+  '--runtime runc ' +
   '-v /var/lib/replicated:/var/lib/replicated -v /proc:/host/proc:ro ' +
   '-p 4700:4700/tcp -p 4702:4702/tcp ' +
   '--link project_postgres_1:postgres --link project_rrservice_1:project_rrservice_1 ' +
@@ -44,6 +45,7 @@ const expectedOneTwo = '\n' +
   '\n\n' +
   'docker run ' +
   '--name hello ' +
+  '--runtime nvidia ' +
   '--volumes-from admiring_brown --volumes-from silly_jang ' +
   '--restart no ' +
   '-h 46d567b2ef86 ' +


### PR DESCRIPTION
Fixes #36.

This change adds the `--runtime` flag to the generated `docker run` command, in order to explicitly support non-default runtimes like `nvidia`.

Note that no magic is done to determine the default runtime (via `/etc/docker/daemon.json` or otherwise) - rekcod will now always blindly include the `--runtime` flag as long as the `Runtime` field is defined in the `docker inspect` output.

This means newly generated `docker run` commands will probably contain `--runtime runc` from existing containers that did not specify a different runtime.