### PR TITLE
chore: bump dev deps, Oct 2019 edition

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: false
 language: node_js
 node_js:
-  - '6'
   - '8'
   - '10'
+  - '12'
   - 'node'
 after_success: npm run coverage

--- a/package.json
+++ b/package.json
@@ -32,10 +32,10 @@
   },
   "homepage": "https://github.com/nexdrew/rekcod#readme",
   "devDependencies": {
-    "coveralls": "^3.0.2",
+    "coveralls": "^3.0.7",
     "nyc": "^14.0.0",
-    "standard": "^14.0.0",
+    "standard": "^14.3.1",
     "standard-version": "^7.0.0",
-    "tape": "^4.9.1"
+    "tape": "^4.11.0"
   }
 }


### PR DESCRIPTION
Also disable npm's inclination to generate package-lock.json.

Also test with Node 12 (which is now LTS) and drop Node 6.