### PR TITLE
feat: handle special characters in cmd

### DIFF
--- a/test/fixtures/inspect-one-two.json
+++ b/test/fixtures/inspect-one-two.json
@@ -362,7 +362,9 @@
         "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
       ],
       "Cmd": [
-        "/hello"
+        "sh",
+        "-c",
+        "(a -a) \u0026\u0026 (b -b)"
       ],
       "Image": "hello-world",
       "Volumes": null,

--- a/test/test-cli.js
+++ b/test/test-cli.js
@@ -41,7 +41,7 @@ const expectedOneTwo = '\n' +
   '-e \'special_char_env_var3=abc()123\' ' +
   '-d ' +
   '--entrypoint "tini -- /docker-entrypoint.sh" ' +
-  'project_service /etc/npme/start.sh -g' +
+  'project_service \'/etc/npme/start.sh\' \'-g\'' +
   '\n\n' +
   'docker run ' +
   '--name hello ' +
@@ -54,7 +54,7 @@ const expectedOneTwo = '\n' +
   '-e \'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\' ' +
   '-a stdout -a stderr ' +
   '-t -i ' +
-  'hello-world /hello' +
+  'hello-world \'sh\' \'-c\' \'(a -a) && (b -b)\'' +
   '\n\n'
 
 test('cli works for docker inspect happy path', (t) => {


### PR DESCRIPTION
Fixes #40.

Wraps each individual piece of the `Config.Cmd` command in single quotes, so that only single quote characters need to be escaped, similar to how env var values are handled in #24.