### PR TITLE
Add Support for --label flags

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,7 +135,7 @@ function toRunCommand (inspectObj, name) {
     rc = appendObjectKeys(rc, '--expose', cfg.ExposedPorts)
   }
   if (cfg.Labels) {
-    rc = appendObjectEntries(rc, '--label', cfg.Labels, '=')
+    rc = appendObjectEntries(rc, '-l', cfg.Labels, '=')
   }
   rc = appendArray(rc, '-e', cfg.Env, quote)
   rc = appendConfigBooleans(rc, cfg)

--- a/index.js
+++ b/index.js
@@ -229,19 +229,19 @@ function appendObjectKeys (str, key, obj, transformer) {
   return newStr
 }
 
-function appendObjectEntries(str, key, obj, joiner) {
-  let newStr = str;
+function appendObjectEntries (str, key, obj, joiner) {
+  let newStr = str
   Array.from(Object.entries(obj)).forEach(([k, v]) => {
     newStr = append(
       newStr,
       key,
       { key: k, val: v },
-      typeof joiner === "function"
+      typeof joiner === 'function'
         ? joiner
         : (agg) => `${quote(agg.key)}${joiner}${quote(agg.val)}`
-    );
-  });
-  return newStr;
+    )
+  })
+  return newStr
 }
 
 function appendArray (str, key, array, transformer) {

--- a/index.js
+++ b/index.js
@@ -238,7 +238,7 @@ function appendObjectEntries (str, key, obj, joiner) {
       { key: k, val: v },
       typeof joiner === 'function'
         ? joiner
-        : (agg) => `${quote(agg.key)}${joiner}${quote(agg.val)}`
+        : (agg) => quote(`${agg.key}${joiner}${agg.val}`)
     )
   })
   return newStr

--- a/index.js
+++ b/index.js
@@ -134,6 +134,9 @@ function toRunCommand (inspectObj, name) {
   if (cfg.ExposedPorts && isCompatible('--expose', modes)) {
     rc = appendObjectKeys(rc, '--expose', cfg.ExposedPorts)
   }
+  if (cfg.Labels && isCompatible('--label', modes)) {
+    rc = appendObjectEntries(rc, '--label', cfg.Labels, '=')
+  }
   rc = appendArray(rc, '-e', cfg.Env, quote)
   rc = appendConfigBooleans(rc, cfg)
   if (cfg.Entrypoint) rc = appendJoinedArray(rc, '--entrypoint', cfg.Entrypoint, ' ')
@@ -224,6 +227,21 @@ function appendObjectKeys (str, key, obj, transformer) {
     })
   })
   return newStr
+}
+
+function appendObjectEntries(str, key, obj, joiner) {
+  let newStr = str;
+  Array.from(Object.entries(obj)).forEach(([k, v]) => {
+    newStr = append(
+      newStr,
+      key,
+      { key: k, val: v },
+      typeof joiner === "function"
+        ? joiner
+        : (agg) => `${quote(agg.key)}${joiner}${quote(agg.val)}`
+    );
+  });
+  return newStr;
 }
 
 function appendArray (str, key, array, transformer) {

--- a/index.js
+++ b/index.js
@@ -134,7 +134,7 @@ function toRunCommand (inspectObj, name) {
   if (cfg.ExposedPorts && isCompatible('--expose', modes)) {
     rc = appendObjectKeys(rc, '--expose', cfg.ExposedPorts)
   }
-  if (cfg.Labels && isCompatible('--label', modes)) {
+  if (cfg.Labels) {
     rc = appendObjectEntries(rc, '--label', cfg.Labels, '=')
   }
   rc = appendArray(rc, '-e', cfg.Env, quote)

--- a/test/test-cli.js
+++ b/test/test-cli.js
@@ -34,6 +34,12 @@ const expectedOneTwo = '\n' +
   '--restart on-failure:5 ' +
   '--add-host xyz:1.2.3.4 --add-host abc:5.6.7.8 ' +
   '--expose 4700/tcp --expose 4702/tcp ' +
+  '-l \'com.docker.compose.config-hash=9f94e0df059d6b68fa0e306b9ee555b4fb9d6dbdb3982a0b0f6c7adca2945f26\' ' +
+  '-l \'com.docker.compose.container-number=1\' ' +
+  '-l \'com.docker.compose.oneoff=False\' ' +
+  '-l \'com.docker.compose.project=project\' ' +
+  '-l \'com.docker.compose.service=service\' ' +
+  '-l \'com.docker.compose.version=1.8.0\' ' +
   '-e \'DB_USER=postgres\' ' +
   '-e \'no_proxy=*.local, 169.254/16\' ' +
   '-e \'special_char_env_var1=abc(!)123\' ' +


### PR DESCRIPTION
Adds support for `--label` flags and introduces a new utility method `appendObjectEntries` to transform

```json5
            "Labels": {
                // ... JSON Object with string key and values
                "traefik.enable": "true",
                "traefik.http.services.some-name.loadbalancer.server.port": "1337"
            }
```

into 

```bash
--label 'traefik.enable'='true' --label 'traefik.http.services.some-name.loadbalancer.server.port'='1337'
```