### PR TITLE
chore: bump docker image to docker:19 base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:18
+FROM docker:19
 
 RUN apk add --no-cache nodejs nodejs-npm
 


### PR DESCRIPTION
Not sure how much bigger this is gonna make the `nexdrew/rekcod` docker image, but seems best to try to keep things up-to-date.

This is just a precursor the v3.0.0 release.